### PR TITLE
 Do not check/set kid.getAlgorithmImplementation if CertificationMode is set to NO_SECURITY

### DIFF
--- a/gsm0348-impl/src/main/java/org/opentelecoms/gsm0348/impl/coders/CardProfileCoder.java
+++ b/gsm0348-impl/src/main/java/org/opentelecoms/gsm0348/impl/coders/CardProfileCoder.java
@@ -3,6 +3,7 @@ package org.opentelecoms.gsm0348.impl.coders;
 import java.util.Arrays;
 
 import org.opentelecoms.gsm0348.api.model.CardProfile;
+import org.opentelecoms.gsm0348.api.model.CertificationMode;
 import org.opentelecoms.gsm0348.api.model.KIC;
 import org.opentelecoms.gsm0348.api.model.KID;
 import org.opentelecoms.gsm0348.api.model.SPI;
@@ -104,78 +105,84 @@ public class CardProfileCoder {
     newCardProfile.setKID(kid);
 
     // The initial chaining value for CBC modes shall be zero.
-    switch (kic.getAlgorithmImplementation()) {
-      case PROPRIETARY_IMPLEMENTATIONS:
-      case ALGORITHM_KNOWN_BY_BOTH_ENTITIES:
-        break;
-      case DES:
-        switch (kic.getCipheringAlgorithmMode()) {
-          case DES_CBC:
-            newCardProfile.setCipheringAlgorithm("DES/CBC/ZeroBytePadding");
-            break;
-
-          case DES_ECB:
-            newCardProfile.setCipheringAlgorithm("DES/ECB/ZeroBytePadding");
-            break;
-
-          case TRIPLE_DES_CBC_2_KEYS:
-          case TRIPLE_DES_CBC_3_KEYS:
-            newCardProfile.setCipheringAlgorithm("DESede/CBC/ZeroBytePadding");
-            break;
-
-          default:
-        }
-        break;
-
-      case AES:
-        // AES shall be used together with counter settings (b5 and b4 of the first octet of SPI) 10 or 11.
-        switch (kic.getCipheringAlgorithmMode()) {
-          case AES_CBC:
-            newCardProfile.setCipheringAlgorithm("AES/CBC/ZeroBytePadding");
-            break;
-          default:
-        }
-        break;
-
-      default:
+    
+    if (spi.getCommandSPI().isCiphered()==true) 
+    {
+	    switch (kic.getAlgorithmImplementation()) {
+	      case PROPRIETARY_IMPLEMENTATIONS:
+	      case ALGORITHM_KNOWN_BY_BOTH_ENTITIES:
+	        break;
+	      case DES:
+	        switch (kic.getCipheringAlgorithmMode()) {
+	          case DES_CBC:
+	            newCardProfile.setCipheringAlgorithm("DES/CBC/ZeroBytePadding");
+	            break;
+	
+	          case DES_ECB:
+	            newCardProfile.setCipheringAlgorithm("DES/ECB/ZeroBytePadding");
+	            break;
+	
+	          case TRIPLE_DES_CBC_2_KEYS:
+	          case TRIPLE_DES_CBC_3_KEYS:
+	            newCardProfile.setCipheringAlgorithm("DESede/CBC/ZeroBytePadding");
+	            break;
+	
+	          default:
+	        }
+	        break;
+	
+	      case AES:
+	        // AES shall be used together with counter settings (b5 and b4 of the first octet of SPI) 10 or 11.
+	        switch (kic.getCipheringAlgorithmMode()) {
+	          case AES_CBC:
+	            newCardProfile.setCipheringAlgorithm("AES/CBC/ZeroBytePadding");
+	            break;
+	          default:
+	        }
+	        break;
+	
+	      default:
+	    }
     }
-
-    switch (kid.getAlgorithmImplementation()) {
-      case CRC:
-        switch (kid.getCertificationAlgorithmMode()) {
-          case CRC_16:
-            newCardProfile.setSignatureAlgorithm("CRC16");
-            break;
-          case CRC_32:
-            newCardProfile.setSignatureAlgorithm("CRC32");
-            break;
-        }
-      case PROPRIETARY_IMPLEMENTATIONS:
-      case ALGORITHM_KNOWN_BY_BOTH_ENTITIES:
-        break;
-      case DES:
-        switch (kid.getCertificationAlgorithmMode()) {
-          case DES_CBC:
-            newCardProfile.setSignatureAlgorithm(SignatureManager.DES_MAC8_ISO9797_M1);
-            break;
-
-          case RESERVED:
-            break;
-
-          case TRIPLE_DES_CBC_2_KEYS:
-          case TRIPLE_DES_CBC_3_KEYS:
-            newCardProfile.setSignatureAlgorithm("DESEDEMAC64");
-            break;
-
-          default:
-        }
-        break;
-      case AES:
-        newCardProfile.setSignatureAlgorithm("AESCMAC");
-        break;
-    }
-
-    return newCardProfile;
+    
+    if (!spi.getCommandSPI().getCertificationMode().equals(CertificationMode.NO_SECURITY))
+    {
+	    switch (kid.getAlgorithmImplementation()) {
+	      case CRC:
+	        switch (kid.getCertificationAlgorithmMode()) {
+	          case CRC_16:
+	            newCardProfile.setSignatureAlgorithm("CRC16");
+	            break;
+	          case CRC_32:
+	            newCardProfile.setSignatureAlgorithm("CRC32");
+	            break;
+	        }
+	      case PROPRIETARY_IMPLEMENTATIONS:
+	      case ALGORITHM_KNOWN_BY_BOTH_ENTITIES:
+	        break;
+	      case DES:
+	        switch (kid.getCertificationAlgorithmMode()) {
+	          case DES_CBC:
+	            newCardProfile.setSignatureAlgorithm(SignatureManager.DES_MAC8_ISO9797_M1);
+	            break;
+	
+	          case RESERVED:
+	            break;
+	
+	          case TRIPLE_DES_CBC_2_KEYS:
+	          case TRIPLE_DES_CBC_3_KEYS:
+	            newCardProfile.setSignatureAlgorithm("DESEDEMAC64");
+	            break;
+	
+	          default:
+	        }
+	        break;
+	      case AES:
+	        newCardProfile.setSignatureAlgorithm("AESCMAC");
+	        break;
+	    }
+	  }
+      return newCardProfile;
   }
 
   /**

--- a/gsm0348-impl/src/main/java/org/opentelecoms/gsm0348/impl/coders/CardProfileCoder.java
+++ b/gsm0348-impl/src/main/java/org/opentelecoms/gsm0348/impl/coders/CardProfileCoder.java
@@ -106,9 +106,7 @@ public class CardProfileCoder {
 
     // The initial chaining value for CBC modes shall be zero.
     
-    if (spi.getCommandSPI().isCiphered()==true) 
-    {
-	    switch (kic.getAlgorithmImplementation()) {
+  	    switch (kic.getAlgorithmImplementation()) {
 	      case PROPRIETARY_IMPLEMENTATIONS:
 	      case ALGORITHM_KNOWN_BY_BOTH_ENTITIES:
 	        break;
@@ -143,7 +141,7 @@ public class CardProfileCoder {
 	
 	      default:
 	    }
-    }
+ 
     
     if (!spi.getCommandSPI().getCertificationMode().equals(CertificationMode.NO_SECURITY))
     {

--- a/gsm0348-impl/src/test/java/org/opentelecoms/gsm0348/impl/coders/CardProfileCoderTest.java
+++ b/gsm0348-impl/src/test/java/org/opentelecoms/gsm0348/impl/coders/CardProfileCoderTest.java
@@ -1,0 +1,26 @@
+package org.opentelecoms.gsm0348.impl.coders;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.opentelecoms.gsm0348.api.model.AlgorithmImplementation;
+import org.opentelecoms.gsm0348.api.model.CardProfile;
+import org.opentelecoms.gsm0348.api.model.KIC;
+import org.opentelecoms.gsm0348.impl.CodingException;
+
+public class CardProfileCoderTest {
+
+	@Test
+	public void test_no_security_card_profile_encoding() throws Exception {
+		
+		byte[] no_security_card_profile = new byte[7];
+		
+		CardProfile cardProfile = CardProfileCoder.encode(no_security_card_profile);
+		
+	    assertEquals(0, cardProfile.getKIC().getKeysetID());
+	    assertEquals(0, cardProfile.getKID().getKeysetID());
+	    assertEquals((byte)0x00, KICCoder.decode(cardProfile.getKIC()));
+	    assertEquals((byte)0x00, KIDCoder.decode(cardProfile.getKID()));
+	  }
+
+}


### PR DESCRIPTION
When SPI1 is set to 00 and KID coding is set to 00, CardProfileCoder is throwing null pointer exception. 