### PR TITLE
recoverCommandPacket reading security for CardProfile on its own

### DIFF
--- a/gsm0348-api/src/main/java/org/opentelecoms/gsm0348/api/PacketBuilder.java
+++ b/gsm0348-api/src/main/java/org/opentelecoms/gsm0348/api/PacketBuilder.java
@@ -108,10 +108,7 @@ public interface PacketBuilder {
    *                     be null.
    * @return {@linkplain CommandPacket}
    * @throws NullPointerException                if data is null or empty.
-   * @throws PacketBuilderConfigurationException if builder if not configured or if ciphering and/or signing
-   *                                             is on but key is not provided.
    * @throws Gsm0348Exception                    in other cases.
    */
-  CommandPacket recoverCommandPacket(byte[] data, byte[] cipheringKey, byte[] signatureKey)
-      throws PacketBuilderConfigurationException, Gsm0348Exception;
+  CommandPacket recoverCommandPacket(byte[] data, byte[] cipheringKey, byte[] signatureKey) throws Gsm0348Exception;
 }

--- a/gsm0348-impl/src/main/java/org/opentelecoms/gsm0348/impl/PacketBuilderFactory.java
+++ b/gsm0348-impl/src/main/java/org/opentelecoms/gsm0348/impl/PacketBuilderFactory.java
@@ -2,7 +2,7 @@ package org.opentelecoms.gsm0348.impl;
 
 import org.opentelecoms.gsm0348.api.PacketBuilder;
 import org.opentelecoms.gsm0348.api.PacketBuilderConfigurationException;
-import org.opentelecoms.gsm0348.api.model.CardProfile;
+import org.opentelecoms.gsm0348.api.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,4 +22,49 @@ public class PacketBuilderFactory {
     LOGGER.debug("Creating new PacketBuilder for {}", cardProfile);
     return new PacketBuilderImpl(cardProfile);
   }
+
+  /**
+   * Creates a default instance with no security applied.
+   * <p>
+   *     Useful for recovering packets with {@link PacketBuilder#recoverCommandPacket(byte[], byte[], byte[])}.
+   * </p>
+   * @return the created packet builder.
+   */
+  public static PacketBuilder getInstance() {
+    CardProfile cardProfile = new CardProfile();
+    cardProfile.setSecurityBytesType(SecurityBytesType.WITH_LENGHTS_AND_UDHL);
+    cardProfile.setTAR(new byte[]{0,0,0});
+    KIC kic = new KIC();
+    kic.setAlgorithmImplementation(AlgorithmImplementation.ALGORITHM_KNOWN_BY_BOTH_ENTITIES);
+    kic.setCipheringAlgorithmMode(CipheringAlgorithmMode.DES_CBC);
+    kic.setKeysetID((byte) 0);
+    cardProfile.setKIC(kic);
+
+    KID kid = new KID();
+    kid.setAlgorithmImplementation(AlgorithmImplementation.ALGORITHM_KNOWN_BY_BOTH_ENTITIES);
+    kid.setCertificationAlgorithmMode(CertificationAlgorithmMode.DES_CBC);
+    kid.setKeysetID((byte) 0);
+    cardProfile.setKID(kid);
+
+    SPI spi = new SPI();
+    CommandSPI commandSPI = new CommandSPI();
+    commandSPI.setCertificationMode(CertificationMode.NO_SECURITY);
+    commandSPI.setCiphered(false);
+    commandSPI.setSynchroCounterMode(SynchroCounterMode.COUNTER_NO_REPLAY_NO_CHECK);
+    spi.setCommandSPI(commandSPI);
+
+    ResponseSPI responseSPI = new ResponseSPI();
+    responseSPI.setCiphered(false);
+    responseSPI.setPoRCertificateMode(CertificationMode.NO_SECURITY);
+    responseSPI.setPoRMode(PoRMode.NO_REPLY);
+    responseSPI.setPoRProtocol(PoRProtocol.SMS_SUBMIT);
+    spi.setResponseSPI(responseSPI);
+    cardProfile.setSPI(spi);
+    try {
+      return getInstance(cardProfile);
+    } catch (PacketBuilderConfigurationException e) {
+      throw new RuntimeException("Could no", e);
+    }
+  }
+
 }

--- a/gsm0348-impl/src/test/java/Gsm0348Test.java
+++ b/gsm0348-impl/src/test/java/Gsm0348Test.java
@@ -355,8 +355,7 @@ public class Gsm0348Test {
     Assert.assertArrayEquals(new byte[]{ (byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04, (byte) 0x05 }, responsePacket.getHeader().getCounter());
     Assert.assertEquals(0x0f, responsePacket.getHeader().getPaddingCounter());
     Assert.assertEquals(POR_OK, responsePacket.getHeader().getResponseStatus());
-    Assert.assertArrayEquals(new byte[]{ (byte) 0x90, (byte) 0x00,
-            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00 },
+    Assert.assertArrayEquals(new byte[]{ (byte) 0x90, (byte) 0x00},
         responsePacket.getData());
   }
 }

--- a/gsm0348-impl/src/test/resources/Dataset0348.xml
+++ b/gsm0348-impl/src/test/resources/Dataset0348.xml
@@ -1050,7 +1050,7 @@
 		<Data>001C12C00203F5909CB8B8F141FEC926024DCF0EB376D4CCFB92BB35177A</Data>
 		<Result>
 			<ResponseResult>
-				<gsm0348:Data>110000000000000000</gsm0348:Data>
+				<gsm0348:Data>1100</gsm0348:Data>
 				<gsm0348:Header>
 					<gsm0348:TAR>C00203</gsm0348:TAR>
 					<gsm0348:PaddingCounter>7</gsm0348:PaddingCounter>


### PR DESCRIPTION
Recovering a command packet with `org.opentelecoms.gsm0348.api.PacketBuilder#recoverCommandPacket`
requires an a priori instance of a `CardProfile` which is always verified for correctness. This is not inconvenient. In fact all settings can be directly read out from the command packet. 
A convenience method to provide and empty `CardProfile` in org.opentelecoms.gsm0348.impl.PacketBuilderFactory#getInstance() was added.
The `recoverCommandPacket` is now decoding the command packet and setting the `CardProfile` to the parses data.

There have been also check for the set `responsePacketCiphering`:

    if (responsePacketCiphering && (cipheringKey == null || cipheringKey.length == 0)) {
      throw new PacketBuilderConfigurationException(
              "Response ciphering is enabled - ciphering key must be specified. Provided: "
                      + ((cipheringKey.length == 0) ? "empty" : Util.toHexArray(cipheringKey)));
    }

	
The checks are now executed on the `commandpacketXYZ` properties.

