### PR TITLE
Fix ciphering config verification error when AlgorithmImplementation …

### DIFF
--- a/gsm0348-impl/src/main/java/org/opentelecoms/gsm0348/impl/PacketBuilderImpl.java
+++ b/gsm0348-impl/src/main/java/org/opentelecoms/gsm0348/impl/PacketBuilderImpl.java
@@ -176,7 +176,8 @@ public class PacketBuilderImpl implements PacketBuilder {
       if (cardProfile.getKIC().getAlgorithmImplementation() == null) {
         throw new PacketBuilderConfigurationException("KIC AlgorithmImplementation cannot be null for ciphered command");
       }
-      if (cardProfile.getKIC().getCipheringAlgorithmMode() == null) {
+      if (cardProfile.getKIC().getCipheringAlgorithmMode() == null &&
+          cardProfile.getKIC().getAlgorithmImplementation() != AlgorithmImplementation.ALGORITHM_KNOWN_BY_BOTH_ENTITIES ) {
         throw new PacketBuilderConfigurationException("KIC CipheringAlgorithmMode cannot be null for ciphered command");
       }
     }


### PR DESCRIPTION
…is ALGORITHM_KNOWN_BY_BOTH_ENTITIES

When KiC coding is set to x4, the card profile verification fails with the following exception:

Caused by: org.opentelecoms.gsm0348.api.PacketBuilderConfigurationException: KIC CipheringAlgorithmMode cannot be null for ciphered command
	at org.opentelecoms.gsm0348.impl.PacketBuilderImpl.verifyProfile(PacketBuilderImpl.java:136)
	at org.opentelecoms.gsm0348.impl.PacketBuilderImpl.setProfile(PacketBuilderImpl.java:296)
	at org.opentelecoms.gsm0348.impl.PacketBuilderImpl.<init>(PacketBuilderImpl.java:87)

The ciphering algorithm mode should not be checked for null if an explicit ciphering algorithm is specified.